### PR TITLE
Remove testing on Photon 5 and final cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,21 +132,6 @@ jobs:
 
 
 
-  photon-5:
-    name: Photon OS 5
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: photon-5
-      display-name: Photon OS 5
-      container-slug: systemd-photon-5
-      timeout: 20
-      instances: '["3006", "3006-8", "3007", "3007-1"]'
-
-
   rockylinux-9:
     name: Rocky Linux 9
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -171,7 +156,6 @@ jobs:
       - lint
       - generate-actions-workflow
       - windows-2022
-      - photon-5
       - rockylinux-9
     if: always()
     steps:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -7,8 +7,8 @@ import pathlib
 os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
 ##    "ubuntu-2204",
+##    "photon-5",
 LINUX_DISTROS = [
-    "photon-5",
     "rockylinux-9",
 ]
 
@@ -44,15 +44,15 @@ VERSION_DISPLAY_NAMES = {
 LATEST_PKG_BLACKLIST = []
 
 ##    "ubuntu-2204": "Ubuntu 22.04",
+##    "photon-5": "Photon OS 5",
 DISTRO_DISPLAY_NAMES = {
-    "photon-5": "Photon OS 5",
     "rockylinux-9": "Rocky Linux 9",
     "windows-2022": "Windows 2022",
 }
 
 ##    "ubuntu-2204": "systemd-ubuntu-22.04",
+##    "photon-5": "systemd-photon-5",
 CONTAINER_SLUG_NAMES = {
-    "photon-5": "systemd-photon-5",
     "rockylinux-9": "systemd-rockylinux-9",
     "windows-2022": "windows-2022",
 }

--- a/linux/svtminion.sh
+++ b/linux/svtminion.sh
@@ -23,8 +23,6 @@ readonly SCRIPT_VERSION='SCRIPT_VERSION_REPLACE'
 
 # definitions
 
-## DGM CURL_DOWNLOAD_RETRY_COUNT=5
-
 ## Repository locations and naming
 readonly default_salt_url_version="latest"
 salt_url_version="${default_salt_url_version}"
@@ -427,9 +425,6 @@ _set_log_level() {
 #   Returns with exit code
 #
 _get_desired_salt_version_fn() {
-    # DGM debug output
-    set -x
-    set -v
 
     if [[ "$#" -ne 1 ]]; then
         _error_log "$0:${FUNCNAME[0]} error expected one parameter "\
@@ -848,50 +843,6 @@ _fetch_vmtools_salt_minion_conf() {
 }
 
 
-## DGM TBD to be removed
-## DGM # _curl_download
-## DGM #
-## DGM #   Retrieve file from specified url to specific file
-## DGM #
-## DGM # Results:
-## DGM #   Exits with 0 or error code
-## DGM #
-## DGM
-## DGM _curl_download() {
-## DGM     local file_name="$1"
-## DGM     local file_url="$2"
-## DGM     local download_retry_failed=1       # assume issues
-## DGM     local _retn=0
-## DGM
-## DGM     _info_log "$0:${FUNCNAME[0]} attempting download of file '${file_name}'"
-## DGM
-## DGM     for ((i=0; i<CURL_DOWNLOAD_RETRY_COUNT; i++))
-## DGM     do
-## DGM         # ensure minimum version of TLS used is v1.2
-## DGM         curl -o "${file_name}" --tlsv1.2 -fsSL "${file_url}"
-## DGM         _retn=$?
-## DGM         if [[ ${_retn} -ne 0 ]]; then
-## DGM             _warning_log "$0:${FUNCNAME[0]} failed to download file "\
-## DGM                 "'${file_name}' from '${file_url}' on '${i}' attempt, "\
-## DGM                 "retcode '${_retn}'"
-## DGM         else
-## DGM             download_retry_failed=0
-## DGM             _debug_log "$0:${FUNCNAME[0]} successfully downloaded file "\
-## DGM                 "'${file_name}' from '${file_url}' after '${i}' attempts"
-## DGM             break
-## DGM         fi
-## DGM     done
-## DGM     if [[ ${download_retry_failed} -ne 0 ]]; then
-## DGM         _error_log "$0:${FUNCNAME[0]} failed to download file '${file_name}' "\
-## DGM             "from '${file_url}' after '${CURL_DOWNLOAD_RETRY_COUNT}' attempts"
-## DGM     fi
-## DGM
-## DGM     _info_log "$0:${FUNCNAME[0]} successfully downloaded file "\
-## DGM         "'${file_name}' from '${file_url}'"
-## DGM     return 0
-## DGM }
-
-
 #
 # _fetch_salt_minion
 #
@@ -909,15 +860,11 @@ _fetch_vmtools_salt_minion_conf() {
 #
 
 _fetch_salt_minion() {
-    # DGM debug output
-    set -x
-    set -v
 
     # fetch the current salt-minion into specified location
     # could check if already there but by always getting it
     # ensure we are not using stale versions
     local _retn=0
-    ## DGM local download_retry_failed=1       # assume issues
 
     local salt_pkg_name=""
     local salt_url=""
@@ -1775,9 +1722,6 @@ _reconfig_fn () {
 #
 
 _install_fn () {
-    # DGM debug output
-    set -x
-    set -v
 
     # execute install of Salt minion
     local _retn=0


### PR DESCRIPTION
### What does this PR do?
Remove testing on Photon 5 and final cleanup

Photon 5 does not provide ```systemd-units``` which the classic 3005 Redhat 9 salt-minion needs, and that is used to test error out if classic packages are installed.

Used to only test against RedHat 8, so not a reduction compared to previous testing on GitLab.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-vmtools/issues/3

