### PR TITLE
Handle double-digit minor versions properly on  Windows

### DIFF
--- a/tests/windows/integration/test_install_exact_ver.ps1
+++ b/tests/windows/integration/test_install_exact_ver.ps1
@@ -1,0 +1,107 @@
+# Copyright 2021-2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2
+
+$test_version = "3006.9"
+
+function setUpScript {
+
+    Write-Host "Resetting environment: " -NoNewline
+    Reset-Environment *> $null
+    Write-Done
+
+    $MinionVersion = $test_version
+    Write-Host "Installing salt ($MinionVersion): " -NoNewline
+    function Get-GuestVars { "master=gv_master id=gv_minion" }
+    Install *> $null
+    Write-Done
+
+}
+
+function tearDownScript {
+    Write-Host "Resetting environment: " -NoNewline
+    Reset-Environment *> $null
+    Write-Done
+}
+
+function test_status_installed {
+    # Is the status set to installed
+    try {
+        $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
+    } catch {
+        $current_status = $STATUS_CODES["notInstalled"]
+    }
+    if ($current_status -ne $STATUS_CODES["installed"]) { return 1 }
+    return 0
+}
+
+function test_ssm_binary_present {
+    # Is the SSM Binary present
+    if (!(Test-Path $ssm_bin)) { return 1 }
+    return 0
+}
+
+function test_binaries_present {
+    # Is salt-call.bat present
+    if (!(Test-Path "$salt_dir\salt-call.exe")) { return 1 }
+    if (!(Test-Path "$salt_dir\salt-minion.exe")) { return 1 }
+    return 0
+}
+
+function test_service_installed {
+    # Is the salt-minion service registerd
+    $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
+    if (!($service)) { return 1 }
+    return 0
+}
+
+function test_service_running {
+    # Is the salt minion service running
+    if ((Get-Service -Name salt-minion).Status -ne "Running") { return 1 }
+    return 0
+}
+
+function test_config_present {
+    # Is the minion config file present
+    if (!(Test-Path $salt_config_file)) { return 1 }
+    return 0
+}
+
+function test_config_correct {
+    # We have to do it this way so -bor will return 0 when both are 0
+    $minion_not_found = 1
+    $master_not_found = 1
+    # Verify that the old minion id is commented out
+    foreach ($line in Get-Content $salt_config_file) {
+        if ($line -match "^id: gv_minion$") { $minion_not_found = 0}
+        if ($line -match "^master: gv_master$") { $master_not_found = 0}
+    }
+    return $minion_not_found -bor $master_not_found
+}
+
+function test_salt_added_to_path {
+    # Has salt been added to the system path
+    $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
+    $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
+    if (!($current_path -like "*$salt_dir*")) { return 1 }
+    return 0
+}
+
+function test_salt_call {
+    $failed = 0
+    $result = & "$salt_dir\salt-call" --local test.ping
+    if (!($result -like "local:*")) { $failed = 1 }
+    if (!($result -like "*True")) { $failed = 1 }
+    return $failed
+}
+
+function test_version {
+    $failed = 0
+    $result = & "$salt_dir\salt-call" --version
+    if (!($result -like "*$test_version*")) {
+        Write-Host ""
+        Write-Host $result
+        Write-Host $test_version
+        $failed = 1
+    }
+    return $failed
+}

--- a/tests/windows/integration/test_install_major.ps1
+++ b/tests/windows/integration/test_install_major.ps1
@@ -1,13 +1,15 @@
 # Copyright 2021-2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2
 
+$test_version = "3006"
+
 function setUpScript {
 
     Write-Host "Resetting environment: " -NoNewline
     Reset-Environment *> $null
     Write-Done
 
-    $MinionVersion = "3006.9"
+    $MinionVersion = $test_version
     Write-Host "Installing salt ($MinionVersion): " -NoNewline
     function Get-GuestVars { "master=gv_master id=gv_minion" }
     Install *> $null
@@ -89,5 +91,21 @@ function test_salt_call {
     $result = & "$salt_dir\salt-call" --local test.ping
     if (!($result -like "local:*")) { $failed = 1 }
     if (!($result -like "*True")) { $failed = 1 }
+    return $failed
+}
+
+function test_version {
+    # This is kind of using the script itself to test the script... maybe need
+    # to get the latest version a different way
+    $versions = Get-AvailableVersions
+    $expected_version = $versions[$test_version]
+    $failed = 0
+    $result = & "$salt_dir\salt-call" --version
+    if (!($result -like "*$expected_version*")) {
+        Write-Host ""
+        Write-Host $result
+        Write-Host $test_version
+        $failed = 1
+    }
     return $failed
 }

--- a/tests/windows/integration/test_upgrade.ps1
+++ b/tests/windows/integration/test_upgrade.ps1
@@ -1,19 +1,22 @@
 # Copyright 2021-2024 VMware, Inc.
 # SPDX-License-Identifier: Apache-2
 
+$start_ver = "3006.0"
+$upgrade_ver = "3006.1"
+
 function setUpScript {
 
     Write-Host "Resetting environment: " -NoNewline
     Reset-Environment *> $null
     Write-Done
 
-    $MinionVersion = "3006.0"
+    $MinionVersion = $start_ver
     Write-Host "Installing salt ($MinionVersion): " -NoNewline
     function Get-GuestVars { "master=existing_master id=existing_minion" }
     Install *> $null
     Write-Done
 
-    $MinionVersion = "3006.1"
+    $MinionVersion = $upgrade_ver
     $Upgrade = $true
     Write-Host "Upgrading salt ($MinionVersion): " -NoNewline
     function Get-GuestVars { "master=gv_master id=gv_minion" }
@@ -91,5 +94,17 @@ function test_salt_call {
     $result = & "$salt_dir\salt-call" --local test.ping
     if (!($result -like "local:*")) { $failed = 1 }
     if (!($result -like "*True")) { $failed = 1 }
+    return $failed
+}
+
+function test_version {
+    $failed = 0
+    $result = & "$salt_dir\salt-call" --version
+    if (!($result -like "*$upgrade_ver*")) {
+        Write-Host ""
+        Write-Host $result
+        Write-Host $upgrade_ver
+        $failed = 1
+    }
     return $failed
 }


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the Windows script where double-digit minor versions are compared correctly. For example, 3006.10 is greater than 3006.9.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-vmtools/issues/34

### Previous Behavior
Minor versions greater than 9 were not considered for latest or latest major version.

### New Behavior
Now latest and major version are correct. As of this PR the latest 3006 version now detects as 3006.17, for example.
