### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     outputs:
       release-version: ${{ steps.update-repo.outputs.release-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
           repository: ${{ github.repository }}


### PR DESCRIPTION
### What does this PR do?
Update actions/checkout to v6 to try to fix the release action failure
