### PR TITLE
Migrate to new method for setting output for changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set Job Output
         id: set-output
         run: |
-          echo "::set-output name=run-tests::${{ steps.changed-files.outputs.any_modified }}"
+          echo "run-tests=${{ steps.changed-files.outputs.any_modified }}" >> $GITHUB_OUTPUT
 
       - name: Set Exit Status
         if: always()

--- a/.github/workflows/templates/ci.yml
+++ b/.github/workflows/templates/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set Job Output
         id: set-output
         run: |
-          echo "::set-output name=run-tests::${{ steps.changed-files.outputs.any_modified }}"
+          echo "run-tests=${{ steps.changed-files.outputs.any_modified }}" >> $GITHUB_OUTPUT
 
       - name: Set Exit Status
         if: always()


### PR DESCRIPTION
### What does this PR do?
We were using a deprecated method for saving a list of changed files. This uses the new method of setting a value and storing it in $GITHUB_STATE
