### PR TITLE
Handle rc releases in the Windows Script

### DIFF
--- a/tests/testarea/3006.10/salt-3006.10-onedir-windows-amd64.zip
+++ b/tests/testarea/3006.10/salt-3006.10-onedir-windows-amd64.zip
@@ -1,0 +1,1 @@
+salt-3007.1-onedir-windows-amd64.zip

--- a/tests/testarea/3006.10rc1/salt-3006.10rc1-onedir-windows-amd64.zip
+++ b/tests/testarea/3006.10rc1/salt-3006.10rc1-onedir-windows-amd64.zip
@@ -1,0 +1,1 @@
+salt-3007.1-onedir-windows-amd64.zip

--- a/tests/windows/functional/test_get_salt_package_info.ps1
+++ b/tests/windows/functional/test_get_salt_package_info.ps1
@@ -2,6 +2,9 @@ function setUpScript {
     $base_url = "$($pwd.Path)\tests\testarea"
 }
 
+# Since this one is going out and getting the actual latest, we don't know
+# exactly what it will return. So, we're just checking that it returned
+# something and that it got a hash, filename, and url
 function test_Get-SaltPackageInfo_online_default {
     $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
     $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
@@ -14,7 +17,7 @@ function test_Get-SaltPackageInfo_online_default {
     return $failed
 }
 
-function test_Get-SaltPackageInfo_online_version{
+function test_Get-SaltPackageInfo_online_exact_version{
     $MinionVersion = "3006.1"
     $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
     $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
@@ -57,6 +60,7 @@ function test_Get-SaltPackageInfo_local_version{
     $base_url = "$($pwd.Path)\tests\testarea"
     $MinionVersion = "3006.1"
     $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
+    if ( $test.version -ne $MinionVersion ) { $failed = 1 }
     $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
     $exp_url = "$base_url/$($test.version)/$exp_name"
     $failed = 0
@@ -71,6 +75,7 @@ function test_Get-SaltPackageInfo_local_major_version{
     $base_url = "$($pwd.Path)\tests\testarea"
     $MinionVersion = "3006"
     $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
+    if ( $test.version -ne "3006.10" ) { $failed = 1 }
     $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
     $exp_url = "$base_url/$($test.version)/$exp_name"
     $failed = 0
@@ -78,5 +83,49 @@ function test_Get-SaltPackageInfo_local_major_version{
     if ( $test.hash.Length -ne 64 ) { $failed = 1 }
     if ( $test.file_name -ne $exp_name ) { $failed = 1 }
     if ( $test.url -ne $exp_url ) { $failed = 1 }
+    return $failed
+}
+
+# testarea includes 3006.10 (GA) and 3006.10rc1 (prerelease). Global "latest"
+# stays 3007.1; major "3006" picks GA 3006.10; exact "3006.10rc1" picks the RC dir.
+function test_Get-SaltPackageInfo_local_latest_unchanged_when_rc_not_highest_ga {
+    $base_url = "$($pwd.Path)\tests\testarea"
+    $MinionVersion = "latest"
+    $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
+    $failed = 0
+    if ( $test.version -ne "3007.1" ) { $failed = 1 }
+    $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
+    $exp_url = "$base_url/$($test.version)/$exp_name"
+    if ( $test.file_name -ne $exp_name ) { $failed = 1 }
+    if ( $test.url -ne $exp_url ) { $failed = 1 }
+    if ( $test.hash.Length -ne 64 ) { $failed = 1 }
+    return $failed
+}
+
+function test_Get-SaltPackageInfo_local_major_3006_resolves_to_ga_not_rc {
+    $base_url = "$($pwd.Path)\tests\testarea"
+    $MinionVersion = "3006"
+    $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
+    $failed = 0
+    if ( $test.version -ne "3006.10" ) { $failed = 1 }
+    $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
+    $exp_url = "$base_url/$($test.version)/$exp_name"
+    if ( $test.file_name -ne $exp_name ) { $failed = 1 }
+    if ( $test.url -ne $exp_url ) { $failed = 1 }
+    if ( $test.hash.Length -notin 0, 64 ) { $failed = 1 }
+    return $failed
+}
+
+function test_Get-SaltPackageInfo_local_exact_rc_version {
+    $base_url = "$($pwd.Path)\tests\testarea"
+    $MinionVersion = "3006.10rc1"
+    $test = Get-SaltPackageInfo -MinionVersion $MinionVersion
+    $failed = 0
+    if ( $test.version -ne "3006.10rc1" ) { $failed = 1 }
+    $exp_name = "salt-$($test.version)-onedir-windows-amd64.zip"
+    $exp_url = "$base_url/$($test.version)/$exp_name"
+    if ( $test.file_name -ne $exp_name ) { $failed = 1 }
+    if ( $test.url -ne $exp_url ) { $failed = 1 }
+    if ( $test.hash.Length -notin 0, 64 ) { $failed = 1 }
     return $failed
 }

--- a/tests/windows/functional/test_version_helpers.ps1
+++ b/tests/windows/functional/test_version_helpers.ps1
@@ -1,0 +1,55 @@
+# Requires runtests.ps1 setup: Import-Module of svtminion.ps1 (Administrator so
+# the script defines functions before its admin gate).
+
+function Test-CalVerHelpersAvailable {
+    return (
+        (Get-Command Test-SaltOnedirVersionIsGA -ErrorAction SilentlyContinue) -and
+        (Get-Command Compare-SaltCalVer -ErrorAction SilentlyContinue)
+    )
+}
+
+function test_Test-SaltOnedirVersionIsGA {
+    if (-not (Test-CalVerHelpersAvailable)) {
+        return 1
+    }
+    $cases = @(
+        @{ Version = "3006.24"; Expected = $true }
+        @{ Version = "3008.0"; Expected = $true }
+        @{ Version = "3006.1"; Expected = $true }
+        @{ Version = "3008.0rc1"; Expected = $false }
+        @{ Version = "3007.1dev1"; Expected = $false }
+        @{ Version = "notaversion"; Expected = $false }
+    )
+    $failed = 0
+    foreach ( $c in $cases ) {
+        $got = Test-SaltOnedirVersionIsGA -Version $c.Version
+        if ( $got -ne $c.Expected ) {
+            $failed = 1
+            break
+        }
+    }
+    return $failed
+}
+
+function test_Compare-SaltCalVer {
+    if (-not (Test-CalVerHelpersAvailable)) {
+        return 1
+    }
+    $cases = @(
+        @{ Left = "3007.1"; Right = "3006.24"; Expected = 1 }
+        @{ Left = "3006.24"; Right = "3007.1"; Expected = -1 }
+        @{ Left = "3006.8"; Right = "3006.8"; Expected = 0 }
+        @{ Left = "3006.24"; Right = "3006.8"; Expected = 1 }
+        @{ Left = "3006.8"; Right = "3006.24"; Expected = -1 }
+        @{ Left = "3008.0"; Right = "3007.99"; Expected = 1 }
+    )
+    $failed = 0
+    foreach ( $c in $cases ) {
+        $got = Compare-SaltCalVer -Left $c.Left -Right $c.Right
+        if ( $got -ne $c.Expected ) {
+            $failed = 1
+            break
+        }
+    }
+    return $failed
+}

--- a/windows/svtminion.ps1
+++ b/windows/svtminion.ps1
@@ -106,10 +106,13 @@ param(
     [Parameter(Mandatory=$false, ParameterSetName="Install")]
     [Alias("m")]
     # The MinionVersion parameter specifies the version of the Salt minion to
-    # install. Use "latest" to install the most recent version available
-    # (default is "latest"). Alternatively, you can specify a major version
-    # number to install the latest release within that version series. For
-    # example, to install the latest release in the 3006 series, pass "3006".
+    # install. Use "latest" to install the most recent GA (general availability)
+    # build at Source; prerelease directories (for example names containing "rc")
+    # are ignored for "latest" and for major-series selection. To install a
+    # prerelease build, pass the exact directory name shown on Source (for example
+    # "3008.0rc1"). Alternatively, specify a major version number to install the
+    # latest GA build in that series (for example pass "3006" for the newest
+    # 3006.x release).
     [String] $MinionVersion="latest",
 
     [Parameter(Mandatory=$false, ParameterSetName="Install")]
@@ -1768,6 +1771,42 @@ function Get-MajorVersion {
 }
 
 
+function Test-SaltOnedirVersionIsGA {
+    # True if the onedir directory name is a GA CalVer (digits and dots only).
+    # Prerelease dirs (e.g. 3008.0rc1) are not GA; install those only via exact
+    # -MinionVersion matching the directory name.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [String] $Version
+    )
+    return [bool]( $Version -match '^\d+\.\d+(\.\d+)*$' )
+}
+
+
+function Compare-SaltCalVer {
+    # Compare two GA numeric CalVer strings (e.g. 3006.24 vs 3007.0). Returns 1
+    # if Left is greater than Right, -1 if less, 0 if equal.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [String] $Left,
+        [Parameter(Mandatory=$true)]
+        [String] $Right
+    )
+    $left_parts = @( ($Left -split '\.') | ForEach-Object { [int]$_ } )
+    $right_parts = @( ($Right -split '\.') | ForEach-Object { [int]$_ } )
+    $max_len = [Math]::Max($left_parts.Count, $right_parts.Count)
+    for ( $i = 0; $i -lt $max_len; $i++ ) {
+        $a = if ( $i -lt $left_parts.Count ) { $left_parts[$i] } else { 0 }
+        $b = if ( $i -lt $right_parts.Count ) { $right_parts[$i] } else { 0 }
+        if ( $a -gt $b ) { return 1 }
+        if ( $a -lt $b ) { return -1 }
+    }
+    return 0
+}
+
+
 function Get-AvailableVersions {
     # Get available versions from a remote location specified in the Source
     # Parameter
@@ -1778,7 +1817,6 @@ function Get-AvailableVersions {
 
     if ( $base_url.StartsWith("http") -or $base_url.StartsWith("ftp") ) {
         # We're dealing with HTTP, HTTPS, or FTP
-        $response = Invoke-WebRequest "$base_url" -UseBasicParsing
         try {
             $response = Invoke-WebRequest "$base_url" -UseBasicParsing
         } catch {
@@ -1794,21 +1832,15 @@ function Get-AvailableVersions {
             exit $STATUS_CODES["scriptFailed"]
         }
 
-        $response.links | ForEach-Object {
-            if ( $_.href.Length -gt 8) {
-                Write-Log "The content at this location is unexpected" -Level error
-                Write-Log "Should be a list of directories where the" -Level error
-                Write-Log "name is a version of Salt" -Level error
-                Set-FailedStatus
-                exit $STATUS_CODES["scriptFailed"]
-            }
-        }
-
-        # Getting available versions from response
+        # Getting available versions from response (Salt onedir dirs: 3006.24,
+        # 3008.0, 3008.0rc1, etc.). Skip non-version links from the index page.
         Write-Log "Getting available versions from response" -Level debug
         $filtered = $response.Links | Where-Object -Property href -NE "../"
-        $filtered | Select-Object -Property href | ForEach-Object {
-            $available_versions.Add($_.href.Trim("/")) | Out-Null
+        $filtered | ForEach-Object {
+            $name = $_.href.Trim("/")
+            if ( $name -match '^\d+\.\d+' ) {
+                $available_versions.Add($name) | Out-Null
+            }
         }
     } elseif ( $base_url.StartsWith("\\") -or $base_url -match "^[A-Za-z]:\\" ) {
         # We're dealing with a local directory or SMB source
@@ -1823,34 +1855,43 @@ function Get-AvailableVersions {
         exit $STATUS_CODES["scriptFailed"]
     }
 
+    if ( $available_versions.Count -eq 0 ) {
+        Write-Log "No version directories found at Source" -Level error
+        Set-FailedStatus
+        exit $STATUS_CODES["scriptFailed"]
+    }
+
     Write-Log "Available versions:" -Level debug
     $available_versions | ForEach-Object {
         Write-Log "- $_" -Level debug
     }
 
     # Create a versions table
-    # This will have the latest version available, the latest version available
-    # for each major version, and every version available. This makes the
-    # version lookup logic easier. The contents of the versions table can be
-    # found in the log or by passing -LogLevel debug
+    # "latest" and each major-series key (3006, 3007, ...) use the newest GA
+    # build only; prerelease dirs still appear under their exact names. Every
+    # discovered directory name is also stored lowercased for lookup. The
+    # contents of the versions table can be found in the log or by passing
+    # -LogLevel debug
     Write-Log "Populating the versions table" -Level debug
     $versions_table = [ordered]@{}
     $available_versions | ForEach-Object {
         $major_version = $(Get-MajorVersion $_)
-        if ( $versions_table.Keys -contains $major_version ) {
-            if ( [System.Version]$_ -gt [System.Version]$versions_table[$major_version] ) {
+        if ( Test-SaltOnedirVersionIsGA $_ ) {
+            if ( $versions_table.Keys -contains $major_version ) {
+                if ( (Compare-SaltCalVer $_ $versions_table[$major_version]) -gt 0 ) {
+                    $versions_table[$major_version] = $_
+                }
+            } else {
                 $versions_table[$major_version] = $_
             }
-        } else {
-            $versions_table[$major_version] = $_
-        }
 
-        if ( $versions_table -contains "latest" ) {
-            if ( [System.Version]$_ -gt [System.Version]$versions_table["latest"] ) {
+            if ( $versions_table.Keys -contains "latest" ) {
+                if ( (Compare-SaltCalVer $_ $versions_table["latest"]) -gt 0 ) {
+                    $versions_table["latest"] = $_
+                }
+            } else {
                 $versions_table["latest"] = $_
             }
-        } else {
-            $versions_table["latest"] = $_
         }
 
         $versions_table[$_.ToLower()] = $_.ToLower()


### PR DESCRIPTION
### What does this PR do?
This change updates how svtminion.ps1 discovers and ranks Salt onedir versions from the index at -Source. latest and major-series requests (for example 3006) now resolve only to GA CalVer directory names (digits and dots). Prerelease directories (names containing segments like rc or dev) are excluded from those aggregations but remain installable when -MinionVersion matches the exact directory name (for example 3008.0rc1).

### Previous Behavior
The script was crashing with the new release of 3008.0rc1

### New Behavior
RC releases are now only installable via exact version name. Latest and major install the latest available GA version or the latest available GA version for the major branch you specified.
