### PR TITLE
Add Salt 3008 test coverage, driven off generate.py's version list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Weekly full test run (all versions), regardless of changed files
+    - cron: "0 0 * * 0"
 
 concurrency:
   # If changes are pushed to a PR, stop all running workflows before starting new ones
@@ -56,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: collect-changed-files
 
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -93,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: collect-changed-files
     container: koalaman/shellcheck-alpine:latest
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: ShellCheck
@@ -117,7 +121,7 @@ jobs:
 
   windows-2022:
     name: Windows 2022
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     uses: ./.github/workflows/test-windows.yml
     needs:
       - lint
@@ -134,7 +138,7 @@ jobs:
 
   rockylinux-9:
     name: Rocky Linux 9
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     uses: ./.github/workflows/test-linux.yml
     needs:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       container-slug: windows-2022
       timeout: 20
       runs-on: windows-2022
-      instances: '["3006", "3006-15", "3007", "3007-7"]'
+      instances: '["3006", "3006-15", "3007", "3007-7", "3008", "3008-1", "upgrade-3007", "upgrade-3008"]'
 
 
 
@@ -144,7 +144,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: systemd-rockylinux-9
       timeout: 20
-      instances: '["3006", "3006-15", "3007", "3007-7"]'
+      instances: '["3006", "3006-15", "3007", "3007-7", "3008", "3008-1", "upgrade-3007", "upgrade-3008"]'
 
 
   set-pipeline-exit-status:

--- a/.github/workflows/templates/ci.yml
+++ b/.github/workflows/templates/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Weekly full test run (all versions), regardless of changed files
+    - cron: "0 0 * * 0"
 
 concurrency:
   # If changes are pushed to a PR, stop all running workflows before starting new ones
@@ -56,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: collect-changed-files
 
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -93,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: collect-changed-files
     container: koalaman/shellcheck-alpine:latest
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.collect-changed-files.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: ShellCheck

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -114,6 +114,21 @@ TIMEOUT_DEFAULT = 20
 TIMEOUT_OVERRIDES = {}
 VERSION_ONLY_OVERRIDES = []
 
+# Test jobs run on every push, on manual (workflow_dispatch) and scheduled
+# (weekly cron, see templates/ci.yml) runs, and on PRs where the
+# collect-changed-files job found relevant files changed.
+RUN_TESTS_IF = (
+    "\n    if: github.event_name == 'push' || "
+    "github.event_name == 'workflow_dispatch' || "
+    "github.event_name == 'schedule' || "
+    "needs.collect-changed-files.outputs.run-tests == 'true'"
+)
+RUN_ALWAYS_IF = (
+    "\n    if: github.event_name == 'push' || "
+    "github.event_name == 'workflow_dispatch' || "
+    "github.event_name == 'schedule'"
+)
+
 TEMPLATE = """
   {distro}:
     name: {display_name}{ifcheck}
@@ -138,7 +153,7 @@ def generate_test_jobs():
     for distro in WINDOWS:
         test_jobs += "\n"
         runs_on = f"\n      runs-on: {distro}"
-        ifcheck = "\n    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'"
+        ifcheck = RUN_TESTS_IF
         uses = "./.github/workflows/test-windows.yml"
         instances = []
         timeout_minutes = (
@@ -169,7 +184,7 @@ def generate_test_jobs():
     for distro in LINUX_DISTROS:
         test_jobs += "\n"
         runs_on = ""
-        ifcheck = "\n    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'"
+        ifcheck = RUN_TESTS_IF
         uses = "./.github/workflows/test-linux.yml"
         instances = []
         timeout_minutes = (
@@ -178,7 +193,7 @@ def generate_test_jobs():
             else TIMEOUT_DEFAULT
         )
         if distro in VERSION_ONLY_OVERRIDES:
-            ifcheck = "\n    if: github.event_name == 'push'"
+            ifcheck = RUN_ALWAYS_IF
 
         for salt_version in SALT_VERSIONS:
            instances.append(salt_version)

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import pathlib
+import sys
 
 os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
@@ -21,6 +22,8 @@ SALT_VERSIONS = [
     "3006-15",
     "3007",
     "3007-7",
+    "3008",
+    "3008-1",
 ]
 
 VERSION_DISPLAY_NAMES = {
@@ -28,7 +31,57 @@ VERSION_DISPLAY_NAMES = {
     "3006-15": "v3006.15",
     "3007": "v3007",
     "3007-7": "v3007.7",
+    "3008": "v3008",
+    "3008-1": "v3008.1",
 }
+
+
+def get_version_pairs():
+    # Derive (major, exact) pairs from SALT_VERSIONS' dash convention, e.g.
+    # "3006-15" -> ("3006", "3006.15"). This is the single source of truth
+    # test suites read to know which exact version to test per major.
+    pairs = []
+    for entry in SALT_VERSIONS:
+        if "-" in entry:
+            major, minor = entry.split("-", 1)
+            pairs.append((major, f"{major}.{minor}"))
+    return pairs
+
+
+def get_major_order():
+    # Ordered list of distinct majors, in the order first seen in
+    # SALT_VERSIONS.
+    seen = []
+    for entry in SALT_VERSIONS:
+        major = entry.split("-", 1)[0]
+        if major not in seen:
+            seen.append(major)
+    return seen
+
+
+def get_upgrade_steps():
+    # One (from_exact, to_major, to_exact) tuple per adjacent major pair,
+    # e.g. ("3006.15", "3007", "3007.7"). Used to derive one CI job per
+    # upgrade step, and for test suites to look up their assigned step.
+    exact_by_major = dict(get_version_pairs())
+    majors = get_major_order()
+    steps = []
+    for prev_major, next_major in zip(majors, majors[1:]):
+        if prev_major in exact_by_major and next_major in exact_by_major:
+            steps.append(
+                (exact_by_major[prev_major], next_major, exact_by_major[next_major])
+            )
+    return steps
+
+
+def print_version_pairs():
+    for major, exact in get_version_pairs():
+        print(f"{major} {exact}")
+
+
+def print_upgrade_steps():
+    for from_exact, to_major, to_exact in get_upgrade_steps():
+        print(f"{from_exact} {to_major} {to_exact}")
 
 
 # TODO: Revert the commit relating to this section, once the Git-based builds
@@ -96,6 +149,8 @@ def generate_test_jobs():
 
         for salt_version in SALT_VERSIONS:
            instances.append(salt_version)
+        for _, to_major, _ in get_upgrade_steps():
+           instances.append(f"upgrade-{to_major}")
 
         if instances:
             needs.append(distro)
@@ -127,6 +182,8 @@ def generate_test_jobs():
 
         for salt_version in SALT_VERSIONS:
            instances.append(salt_version)
+        for _, to_major, _ in get_upgrade_steps():
+           instances.append(f"upgrade-{to_major}")
 
         if instances:
             needs.append(distro)
@@ -152,4 +209,9 @@ def generate_test_jobs():
 
 
 if __name__ == "__main__":
-    generate_test_jobs()
+    if "--print-versions" in sys.argv:
+        print_version_pairs()
+    elif "--print-upgrade-steps" in sys.argv:
+        print_upgrade_steps()
+    else:
+        generate_test_jobs()

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: VMTools Salt
+        if: ${{ !startsWith(matrix.instance, 'upgrade-') }}
         run: |
           # sed 1st - becomes space, 2nd - becomes dot
           bt_parms=$(echo "${{ matrix.instance }}" | sed 's/-/ /' | sed 's/-/./')
@@ -55,6 +56,8 @@ jobs:
           bash -x ./linux/svtminion.sh "$bt_arg1" "$bt_arg2"
 
       - name: Test VMTools
+        env:
+          SALT_TEST_VERSION: ${{ matrix.instance }}
         run: |
           bash -x ./tests/linux/test-linux.sh
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Test SVT Minion Script
+        env:
+          SALT_TEST_VERSION: ${{ matrix.instance }}
         run: |
           # Make sure we can run the script
           Write-Host "Run Script (no parameters)"

--- a/tests/linux/test-linux.sh
+++ b/tests/linux/test-linux.sh
@@ -215,17 +215,15 @@ _run_upgrade_check() {
 
     ./svtminion.sh --upgrade --install --loglevel debug --minionversion "${_to}"
 
-    # Full battery after the upgrade - this is the state that matters.
+    # Only check things that relate to the upgrade itself - binaries
+    # present and ping are already covered by the fresh-install tests and
+    # don't exercise anything upgrade-specific.
     ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed after upgrade ${_from} -> ${_to}, returned '${_retn}'"; exit 1; fi; }
-    ls -alh /opt/saltstack/salt/salt-minion || { echo "test failed, salt-minion binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
-    ls -alh /usr/bin/salt-call || { echo "test failed, salt-call binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
-    ls -alh /usr/bin/salt-minion || { echo "test failed, salt-minion binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
-    ps -ef | grep salt
     systemctl is-active salt-minion || { echo "test failed, salt-minion service not active after upgrade ${_from} -> ${_to}"; exit 1; }
-    cat /etc/salt/minion
+    # An upgrade preserves the existing config - the guest vars passed to
+    # the upgrade call above are expected to be ignored.
     cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null || { echo "test failed, master not preserved after upgrade ${_from} -> ${_to}"; exit 1; }
     cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null || { echo "test failed, id not preserved after upgrade ${_from} -> ${_to}"; exit 1; }
-    /usr/bin/salt-call --local test.ping | grep -qi "true" || { echo "test failed, salt-call test.ping failed after upgrade ${_from} -> ${_to}"; exit 1; }
     if [[ "$(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2)" != "${_to}" ]]; then echo "test failed, wrong version after upgrade ${_from} -> ${_to}"; exit 1; fi
 
     ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }

--- a/tests/linux/test-linux.sh
+++ b/tests/linux/test-linux.sh
@@ -209,12 +209,25 @@ _run_exact_check() {
 
 _run_upgrade_check() {
     local _from="$1" _to="$2"
+    # Thin check before the upgrade - just confirm the starting version.
     ./svtminion.sh --install master=192.168.0.5 id="tup" --loglevel debug --minionversion "${_from}"
     if [[ "$(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2)" != "${_from}" ]]; then echo "test failed, wrong starting version for upgrade ${_from} -> ${_to}"; exit 1; fi
+
     ./svtminion.sh --upgrade --install --loglevel debug --minionversion "${_to}"
-    cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
-    cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null
+
+    # Full battery after the upgrade - this is the state that matters.
+    ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed after upgrade ${_from} -> ${_to}, returned '${_retn}'"; exit 1; fi; }
+    ls -alh /opt/saltstack/salt/salt-minion || { echo "test failed, salt-minion binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
+    ls -alh /usr/bin/salt-call || { echo "test failed, salt-call binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
+    ls -alh /usr/bin/salt-minion || { echo "test failed, salt-minion binary missing after upgrade ${_from} -> ${_to}"; exit 1; }
+    ps -ef | grep salt
+    systemctl is-active salt-minion || { echo "test failed, salt-minion service not active after upgrade ${_from} -> ${_to}"; exit 1; }
+    cat /etc/salt/minion
+    cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null || { echo "test failed, master not preserved after upgrade ${_from} -> ${_to}"; exit 1; }
+    cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null || { echo "test failed, id not preserved after upgrade ${_from} -> ${_to}"; exit 1; }
+    /usr/bin/salt-call --local test.ping | grep -qi "true" || { echo "test failed, salt-call test.ping failed after upgrade ${_from} -> ${_to}"; exit 1; }
     if [[ "$(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2)" != "${_to}" ]]; then echo "test failed, wrong version after upgrade ${_from} -> ${_to}"; exit 1; fi
+
     ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }
 }
 

--- a/tests/linux/test-linux.sh
+++ b/tests/linux/test-linux.sh
@@ -181,19 +181,66 @@ else
 fi
 ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }
 
-./svtminion.sh --source ${oldpwd}/tests/testarea --install master=192.168.0.5 --loglevel debug --minionversion 3007
-./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed, returned '${_retn}'"; exit 1; fi; }
-sleep 1
-cat /etc/salt/minion
-cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
-## wait for RC with 3008
-## ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; }
-## ./svtminion.sh --install master=192.168.0.5 --loglevel debug --source https://packages.broadcom.com/artifactory/saltproject-generic/onedir
-## ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed, returned '${_retn}'"; exit 1; fi; }
-## sleep 1
-cat /etc/salt/minion
-cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
-./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; }
+## Major-version, exact-version, and upgrade-chain coverage, data-driven off
+## generate.py's SALT_VERSIONS (the single source of truth for which Salt
+## versions this repo tests). Sourced from the real network default so this
+## also exercises real packages.broadcom.com resolution, not local testarea
+## fixtures. Gated by $SALT_TEST_VERSION so each CI matrix job exercises
+## only its assigned entry; unset (local ad-hoc run) exercises all of them.
+_generate_py="${oldpwd}/.github/workflows/templates/generate.py"
+
+_run_major_check() {
+    local _major="$1"
+    ./svtminion.sh --install master=192.168.0.5 --loglevel debug --minionversion "${_major}"
+    ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed (major ${_major}), returned '${_retn}'"; exit 1; fi; }
+    cat /etc/salt/minion
+    cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
+    ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }
+}
+
+_run_exact_check() {
+    local _exact="$1"
+    ./svtminion.sh --install master=192.168.0.5 --loglevel debug --minionversion "${_exact}"
+    ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed (exact ${_exact}), returned '${_retn}'"; exit 1; fi; }
+    _ver_out=$(/usr/bin/salt-call --local test.version --out=txt 2>/dev/null || true)
+    if echo "${_ver_out}" | grep -q "${_exact}"; then echo "test correct"; else echo "test failed: expected ${_exact} in test.version, got '${_ver_out}'"; exit 1; fi
+    ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }
+}
+
+_run_upgrade_check() {
+    local _from="$1" _to="$2"
+    ./svtminion.sh --install master=192.168.0.5 id="tup" --loglevel debug --minionversion "${_from}"
+    if [[ "$(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2)" != "${_from}" ]]; then echo "test failed, wrong starting version for upgrade ${_from} -> ${_to}"; exit 1; fi
+    ./svtminion.sh --upgrade --install --loglevel debug --minionversion "${_to}"
+    cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
+    cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null
+    if [[ "$(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2)" != "${_to}" ]]; then echo "test failed, wrong version after upgrade ${_from} -> ${_to}"; exit 1; fi
+    ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; exit 1; }
+}
+
+if [[ "${SALT_TEST_VERSION:-}" =~ ^upgrade-([0-9]+)$ ]]; then
+    _to_major="${BASH_REMATCH[1]}"
+    while read -r _from_exact _to_major_row _to_exact; do
+        if [[ "${_to_major_row}" == "${_to_major}" ]]; then
+            _run_upgrade_check "${_from_exact}" "${_to_exact}"
+        fi
+    done < <(python3 "${_generate_py}" --print-upgrade-steps)
+elif [[ -n "${SALT_TEST_VERSION:-}" ]]; then
+    if [[ "${SALT_TEST_VERSION}" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+        _run_exact_check "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+    elif [[ "${SALT_TEST_VERSION}" =~ ^[0-9]+$ ]]; then
+        _run_major_check "${SALT_TEST_VERSION}"
+    fi
+else
+    while read -r _major _exact; do
+        _run_major_check "${_major}"
+        _run_exact_check "${_exact}"
+    done < <(python3 "${_generate_py}" --print-versions)
+    while read -r _from_exact _to_major _to_exact; do
+        _run_upgrade_check "${_from_exact}" "${_to_exact}"
+    done < <(python3 "${_generate_py}" --print-upgrade-steps)
+fi
+
 # test stop and start
 ./svtminion.sh --install master=192.168.0.5 --loglevel debug --source https://packages.broadcom.com/artifactory/saltproject-generic/onedir
 ./svtminion.sh --status --loglevel debug || { _retn=$?; if [[ ${_retn} -eq 100 ]]; then echo "test correct"; else echo "test failed, salt-minion should be installed, returned '${_retn}'"; exit 1; fi; }
@@ -218,23 +265,10 @@ cat /etc/salt/minion
 cat /etc/salt/minion | grep 'master:\ 192.168.0.7' 1>/dev/null
 ps -ef | grep salt
 systemctl is-active salt-minion
-# test 3006-3007 and upgrade
+## The 3006->3007->3008 upgrade chain is now covered above by the
+## data-driven _run_upgrade_check loop.
 ./svtminion.sh --remove || { _retn=$?; echo "test failed, did not uninstall the salt-minion, returned '${_retn}'"; }
 sleep 1
-./svtminion.sh --source ${oldpwd}/tests/testarea --install master=192.168.0.5 id="tup" --loglevel debug --minionversion 3006
-cat /etc/salt/minion
-cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
-cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null
-ps -ef | grep salt
-systemctl is-active salt-minion
-if [[ $(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2 | awk -F "." '{print $1}') -eq 3006 ]]; then echo "test correct"; else echo "test failed, wrong major version for salt-minion"; exit 1; fi
-./svtminion.sh --source ${oldpwd}/tests/testarea --upgrade --install --loglevel debug --minionversion 3007
-cat /etc/salt/minion
-cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null
-cat /etc/salt/minion | grep 'id:\ tup' 1>/dev/null
-ps -ef | grep salt
-systemctl is-active salt-minion
-if [[ $(/usr/bin/salt-call --local test.version --out=pprint | awk '{print $2}' | cut -d "'" -f 2 | awk -F "." '{print $1}') -eq 3007 ]]; then echo "test correct"; else echo "test failed, wrong major version for salt-minion"; exit 1; fi
 ./svtminion.sh --source ${oldpwd}/tests/testarea --install master=192.168.0.5 --loglevel debug
 cat /etc/salt/minion
 cat /etc/salt/minion | grep 'master:\ 192.168.0.5' 1>/dev/null

--- a/tests/windows/helpers.ps1
+++ b/tests/windows/helpers.ps1
@@ -55,6 +55,44 @@ function Write-Done {
     Write-Host "Done" -ForegroundColor Yellow
 }
 
+function Get-SaltTestPythonCommand {
+    # Prefer `python`, fall back to the `py` launcher
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return "python"
+    }
+    return "py"
+}
+
+function Get-SaltTestVersionPairs {
+    # Reads the major/exact version pairs from generate.py, the single
+    # source of truth for which Salt versions the test suites cover. Returns
+    # an ordered array of @{ Major = ...; Exact = ... }.
+    $python = Get-SaltTestPythonCommand
+    $generate_py = ".github\workflows\templates\generate.py"
+    $lines = & $python $generate_py --print-versions
+    $pairs = [System.Collections.ArrayList]::new()
+    foreach ($line in $lines) {
+        $major, $exact = $line -split '\s+'
+        $pairs.Add(@{ Major = $major; Exact = $exact }) | Out-Null
+    }
+    return $pairs
+}
+
+function Get-SaltTestUpgradeSteps {
+    # Reads the upgrade-step list (one per adjacent major pair) from
+    # generate.py. Returns an ordered array of
+    # @{ FromExact = ...; ToMajor = ...; ToExact = ... }.
+    $python = Get-SaltTestPythonCommand
+    $generate_py = ".github\workflows\templates\generate.py"
+    $lines = & $python $generate_py --print-upgrade-steps
+    $steps = [System.Collections.ArrayList]::new()
+    foreach ($line in $lines) {
+        $from_exact, $to_major, $to_exact = $line -split '\s+'
+        $steps.Add(@{ FromExact = $from_exact; ToMajor = $to_major; ToExact = $to_exact }) | Out-Null
+    }
+    return $steps
+}
+
 function Reset-Environment {
     # Stop and remove the salt-minion service if it exists
     $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue

--- a/tests/windows/integration/test_install_exact_ver.ps1
+++ b/tests/windows/integration/test_install_exact_ver.ps1
@@ -1,17 +1,20 @@
-$test_version = "3006.9"
+function Get-ExactVersionsUnderTest {
+    $env_value = $env:SALT_TEST_VERSION
+    if (-not $env_value) {
+        # Local ad-hoc run: exercise every exact Salt version under test.
+        return @(Get-SaltTestVersionPairs | ForEach-Object { $_.Exact })
+    }
+    if ($env_value -match '^(\d+)-(\d+)$') {
+        return @("$($Matches[1]).$($Matches[2])")
+    }
+    # Major-only or upgrade-step job - exact-version install isn't its concern.
+    return @()
+}
 
 function setUpScript {
-
     Write-Host "Resetting environment: " -NoNewline
     Reset-Environment *> $null
     Write-Done
-
-    $MinionVersion = $test_version
-    Write-Host "Installing salt ($MinionVersion): " -NoNewline
-    function Get-GuestVars { "master=gv_master id=gv_minion" }
-    Install *> $null
-    Write-Done
-
 }
 
 function tearDownScript {
@@ -20,85 +23,73 @@ function tearDownScript {
     Write-Done
 }
 
-function test_status_installed {
-    # Is the status set to installed
-    try {
-        $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
-    } catch {
-        $current_status = $STATUS_CODES["notInstalled"]
+function test_install_exact_versions {
+    $exact_versions = Get-ExactVersionsUnderTest
+    if ($exact_versions.Count -eq 0) {
+        Write-Host "Skipped - this job does not cover exact-version installs"
+        return 0
     }
-    if ($current_status -ne $STATUS_CODES["installed"]) { return 1 }
-    return 0
-}
 
-function test_ssm_binary_present {
-    # Is the SSM Binary present
-    if (!(Test-Path $ssm_bin)) { return 1 }
-    return 0
-}
-
-function test_binaries_present {
-    # Is salt-call.bat present
-    if (!(Test-Path "$salt_dir\salt-call.exe")) { return 1 }
-    if (!(Test-Path "$salt_dir\salt-minion.exe")) { return 1 }
-    return 0
-}
-
-function test_service_installed {
-    # Is the salt-minion service registerd
-    $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
-    if (!($service)) { return 1 }
-    return 0
-}
-
-function test_service_running {
-    # Is the salt minion service running
-    if ((Get-Service -Name salt-minion).Status -ne "Running") { return 1 }
-    return 0
-}
-
-function test_config_present {
-    # Is the minion config file present
-    if (!(Test-Path $salt_config_file)) { return 1 }
-    return 0
-}
-
-function test_config_correct {
-    # We have to do it this way so -bor will return 0 when both are 0
-    $minion_not_found = 1
-    $master_not_found = 1
-    # Verify that the old minion id is commented out
-    foreach ($line in Get-Content $salt_config_file) {
-        if ($line -match "^id: gv_minion$") { $minion_not_found = 0}
-        if ($line -match "^master: gv_master$") { $master_not_found = 0}
-    }
-    return $minion_not_found -bor $master_not_found
-}
-
-function test_salt_added_to_path {
-    # Has salt been added to the system path
-    $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
-    $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
-    if (!($current_path -like "*$salt_dir*")) { return 1 }
-    return 0
-}
-
-function test_salt_call {
     $failed = 0
-    $result = & "$salt_dir\salt-call" --local test.ping
-    if (!($result -like "local:*")) { $failed = 1 }
-    if (!($result -like "*True")) { $failed = 1 }
-    return $failed
-}
-
-function test_version {
-    $failed = 0
-    $result = & "$salt_dir\salt-call" --version
-    if (!($result -like "*$test_version*")) {
+    foreach ($test_version in $exact_versions) {
         Write-Host ""
-        Write-Host $result
-        Write-Host $test_version
-        $failed = 1
+        Write-Host "Testing exact version: $test_version"
+
+        $MinionVersion = $test_version
+        function Get-GuestVars { "master=gv_master id=gv_minion" }
+        Write-Host "Installing salt ($MinionVersion): " -NoNewline
+        Install *> $null
+        Write-Done
+
+        try {
+            $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
+        } catch {
+            $current_status = $STATUS_CODES["notInstalled"]
+        }
+        if ($current_status -ne $STATUS_CODES["installed"]) {
+            $failed = 1; Write-Host "FAILED ($test_version): status not installed"
+        }
+
+        if (!(Test-Path $ssm_bin)) { $failed = 1; Write-Host "FAILED ($test_version): ssm binary missing" }
+        if (!(Test-Path "$salt_dir\salt-call.exe")) { $failed = 1; Write-Host "FAILED ($test_version): salt-call.exe missing" }
+        if (!(Test-Path "$salt_dir\salt-minion.exe")) { $failed = 1; Write-Host "FAILED ($test_version): salt-minion.exe missing" }
+
+        $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
+        if (!($service)) { $failed = 1; Write-Host "FAILED ($test_version): service not registered" }
+        elseif ($service.Status -ne "Running") { $failed = 1; Write-Host "FAILED ($test_version): service not running" }
+
+        if (!(Test-Path $salt_config_file)) { $failed = 1; Write-Host "FAILED ($test_version): config missing" }
+
+        $minion_not_found = 1
+        $master_not_found = 1
+        foreach ($line in Get-Content $salt_config_file) {
+            if ($line -match "^id: gv_minion$") { $minion_not_found = 0 }
+            if ($line -match "^master: gv_master$") { $master_not_found = 0 }
+        }
+        if ($minion_not_found -or $master_not_found) {
+            $failed = 1; Write-Host "FAILED ($test_version): config incorrect"
+        }
+
+        $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
+        $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
+        if (!($current_path -like "*$salt_dir*")) {
+            $failed = 1; Write-Host "FAILED ($test_version): salt not added to path"
+        }
+
+        $result = & "$salt_dir\salt-call" --local test.ping
+        if (!($result -like "local:*") -or !($result -like "*True")) {
+            $failed = 1; Write-Host "FAILED ($test_version): salt-call test.ping failed"
+        }
+
+        $result = & "$salt_dir\salt-call" --version
+        if (!($result -like "*$test_version*")) {
+            $failed = 1
+            Write-Host "FAILED ($test_version): expected version $test_version, got: $result"
+        }
+
+        Write-Host "Resetting environment: " -NoNewline
+        Reset-Environment *> $null
+        Write-Done
     }
     return $failed
 }

--- a/tests/windows/integration/test_install_major.ps1
+++ b/tests/windows/integration/test_install_major.ps1
@@ -1,17 +1,20 @@
-$test_version = "3006"
+function Get-MajorVersionsUnderTest {
+    $env_value = $env:SALT_TEST_VERSION
+    if (-not $env_value) {
+        # Local ad-hoc run: exercise every major Salt version under test.
+        return @(Get-SaltTestVersionPairs | ForEach-Object { $_.Major })
+    }
+    if ($env_value -match '^\d+$') {
+        return @($env_value)
+    }
+    # Exact-version or upgrade-step job - major-version install isn't its concern.
+    return @()
+}
 
 function setUpScript {
-
     Write-Host "Resetting environment: " -NoNewline
     Reset-Environment *> $null
     Write-Done
-
-    $MinionVersion = $test_version
-    Write-Host "Installing salt ($MinionVersion): " -NoNewline
-    function Get-GuestVars { "master=gv_master id=gv_minion" }
-    Install *> $null
-    Write-Done
-
 }
 
 function tearDownScript {
@@ -20,89 +23,78 @@ function tearDownScript {
     Write-Done
 }
 
-function test_status_installed {
-    # Is the status set to installed
-    try {
-        $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
-    } catch {
-        $current_status = $STATUS_CODES["notInstalled"]
+function test_install_major_versions {
+    $majors = Get-MajorVersionsUnderTest
+    if ($majors.Count -eq 0) {
+        Write-Host "Skipped - this job does not cover major-version installs"
+        return 0
     }
-    if ($current_status -ne $STATUS_CODES["installed"]) { return 1 }
-    return 0
-}
 
-function test_ssm_binary_present {
-    # Is the SSM Binary present
-    if (!(Test-Path $ssm_bin)) { return 1 }
-    return 0
-}
-
-function test_binaries_present {
-    # Is salt-call.bat present
-    if (!(Test-Path "$salt_dir\salt-call.exe")) { return 1 }
-    if (!(Test-Path "$salt_dir\salt-minion.exe")) { return 1 }
-    return 0
-}
-
-function test_service_installed {
-    # Is the salt-minion service registerd
-    $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
-    if (!($service)) { return 1 }
-    return 0
-}
-
-function test_service_running {
-    # Is the salt minion service running
-    if ((Get-Service -Name salt-minion).Status -ne "Running") { return 1 }
-    return 0
-}
-
-function test_config_present {
-    # Is the minion config file present
-    if (!(Test-Path $salt_config_file)) { return 1 }
-    return 0
-}
-
-function test_config_correct {
-    # We have to do it this way so -bor will return 0 when both are 0
-    $minion_not_found = 1
-    $master_not_found = 1
-    # Verify that the old minion id is commented out
-    foreach ($line in Get-Content $salt_config_file) {
-        if ($line -match "^id: gv_minion$") { $minion_not_found = 0}
-        if ($line -match "^master: gv_master$") { $master_not_found = 0}
-    }
-    return $minion_not_found -bor $master_not_found
-}
-
-function test_salt_added_to_path {
-    # Has salt been added to the system path
-    $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
-    $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
-    if (!($current_path -like "*$salt_dir*")) { return 1 }
-    return 0
-}
-
-function test_salt_call {
     $failed = 0
-    $result = & "$salt_dir\salt-call" --local test.ping
-    if (!($result -like "local:*")) { $failed = 1 }
-    if (!($result -like "*True")) { $failed = 1 }
-    return $failed
-}
-
-function test_version {
-    # This is kind of using the script itself to test the script... maybe need
-    # to get the latest version a different way
-    $versions = Get-AvailableVersions
-    $expected_version = $versions[$test_version]
-    $failed = 0
-    $result = & "$salt_dir\salt-call" --version
-    if (!($result -like "*$expected_version*")) {
+    foreach ($major in $majors) {
         Write-Host ""
-        Write-Host $result
-        Write-Host $test_version
-        $failed = 1
+        Write-Host "Testing major version: $major"
+
+        $MinionVersion = $major
+        function Get-GuestVars { "master=gv_master id=gv_minion" }
+        Write-Host "Installing salt ($MinionVersion): " -NoNewline
+        Install *> $null
+        Write-Done
+
+        # This is kind of using the script itself to test the script... maybe
+        # need to get the latest version a different way
+        $versions = Get-AvailableVersions
+        $expected_version = $versions[$major]
+
+        try {
+            $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
+        } catch {
+            $current_status = $STATUS_CODES["notInstalled"]
+        }
+        if ($current_status -ne $STATUS_CODES["installed"]) {
+            $failed = 1; Write-Host "FAILED ($major): status not installed"
+        }
+
+        if (!(Test-Path $ssm_bin)) { $failed = 1; Write-Host "FAILED ($major): ssm binary missing" }
+        if (!(Test-Path "$salt_dir\salt-call.exe")) { $failed = 1; Write-Host "FAILED ($major): salt-call.exe missing" }
+        if (!(Test-Path "$salt_dir\salt-minion.exe")) { $failed = 1; Write-Host "FAILED ($major): salt-minion.exe missing" }
+
+        $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
+        if (!($service)) { $failed = 1; Write-Host "FAILED ($major): service not registered" }
+        elseif ($service.Status -ne "Running") { $failed = 1; Write-Host "FAILED ($major): service not running" }
+
+        if (!(Test-Path $salt_config_file)) { $failed = 1; Write-Host "FAILED ($major): config missing" }
+
+        $minion_not_found = 1
+        $master_not_found = 1
+        foreach ($line in Get-Content $salt_config_file) {
+            if ($line -match "^id: gv_minion$") { $minion_not_found = 0 }
+            if ($line -match "^master: gv_master$") { $master_not_found = 0 }
+        }
+        if ($minion_not_found -or $master_not_found) {
+            $failed = 1; Write-Host "FAILED ($major): config incorrect"
+        }
+
+        $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
+        $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
+        if (!($current_path -like "*$salt_dir*")) {
+            $failed = 1; Write-Host "FAILED ($major): salt not added to path"
+        }
+
+        $result = & "$salt_dir\salt-call" --local test.ping
+        if (!($result -like "local:*") -or !($result -like "*True")) {
+            $failed = 1; Write-Host "FAILED ($major): salt-call test.ping failed"
+        }
+
+        $result = & "$salt_dir\salt-call" --version
+        if (!($result -like "*$expected_version*")) {
+            $failed = 1
+            Write-Host "FAILED ($major): expected version $expected_version, got: $result"
+        }
+
+        Write-Host "Resetting environment: " -NoNewline
+        Reset-Environment *> $null
+        Write-Done
     }
     return $failed
 }

--- a/tests/windows/integration/test_upgrade.ps1
+++ b/tests/windows/integration/test_upgrade.ps1
@@ -1,25 +1,21 @@
-$start_ver = "3006.0"
-$upgrade_ver = "3006.1"
+function Get-UpgradeStepsUnderTest {
+    $env_value = $env:SALT_TEST_VERSION
+    if (-not $env_value) {
+        # Local ad-hoc run: exercise every upgrade step under test.
+        return @(Get-SaltTestUpgradeSteps)
+    }
+    if ($env_value -match '^upgrade-(\d+)$') {
+        $to_major = $Matches[1]
+        return @(Get-SaltTestUpgradeSteps | Where-Object { $_.ToMajor -eq $to_major })
+    }
+    # Major-only or exact-version job - upgrade isn't its concern.
+    return @()
+}
 
 function setUpScript {
-
     Write-Host "Resetting environment: " -NoNewline
     Reset-Environment *> $null
     Write-Done
-
-    $MinionVersion = $start_ver
-    Write-Host "Installing salt ($MinionVersion): " -NoNewline
-    function Get-GuestVars { "master=existing_master id=existing_minion" }
-    Install *> $null
-    Write-Done
-
-    $MinionVersion = $upgrade_ver
-    $Upgrade = $true
-    Write-Host "Upgrading salt ($MinionVersion): " -NoNewline
-    function Get-GuestVars { "master=gv_master id=gv_minion" }
-    Install *> $null
-    Write-Done
-
 }
 
 function tearDownScript {
@@ -28,80 +24,85 @@ function tearDownScript {
     Write-Done
 }
 
-function test_status_installed {
-    # Is the status set to installed
-    try {
-        $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
-    } catch {
-        $current_status = $STATUS_CODES["notInstalled"]
+function test_upgrade_steps {
+    $steps = Get-UpgradeStepsUnderTest
+    if ($steps.Count -eq 0) {
+        Write-Host "Skipped - this job does not cover upgrade testing"
+        return 0
     }
-    if ($current_status -ne $STATUS_CODES["installed"]) { return 1 }
-    return 0
-}
 
-function test_binaries_present{
-    # Is the SSM Binary present
-    if (!(Test-Path $ssm_bin)) { return 1 }
-    if (!(Test-Path "$salt_dir\salt-call.exe")) { return 1 }
-    if (!(Test-Path "$salt_dir\salt-minion.exe")) { return 1 }
-    return 0
-}
-
-function test_service_installed {
-    # Is the salt-minion service registerd
-    $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
-    if (!($service)) { return 1 }
-    return 0
-}
-
-function test_service_running {
-    # Is the salt minion service running
-    if ((Get-Service -Name salt-minion).Status -ne "Running") { return 1 }
-    return 0
-}
-
-function test_config_present {
-    # Is the minion config file present
-    if (!(Test-Path $salt_config_file)) { return 1 }
-    return 0
-}
-
-function test_config_correct {
-    # We have to do it this way so -bor will return 0 when both are 0
-    $minion_not_found = 1
-    $master_not_found = 1
-    # Verify that the old minion id is commented out
-    foreach ($line in Get-Content $salt_config_file) {
-        if ($line -match "^id: existing_minion$") { $minion_not_found = 0}
-        if ($line -match "^master: existing_master$") { $master_not_found = 0}
-    }
-    return $minion_not_found -bor $master_not_found
-}
-
-function test_salt_added_to_path {
-    # Has salt been added to the system path
-    $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
-    $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
-    if (!($current_path -like "*$salt_dir*")) { return 1 }
-    return 0
-}
-
-function test_salt_call {
     $failed = 0
-    $result = & "$salt_dir\salt-call" --local test.ping
-    if (!($result -like "local:*")) { $failed = 1 }
-    if (!($result -like "*True")) { $failed = 1 }
-    return $failed
-}
-
-function test_version {
-    $failed = 0
-    $result = & "$salt_dir\salt-call" --version
-    if (!($result -like "*$upgrade_ver*")) {
+    foreach ($step in $steps) {
+        $start_ver = $step.FromExact
+        $upgrade_ver = $step.ToExact
         Write-Host ""
-        Write-Host $result
-        Write-Host $upgrade_ver
-        $failed = 1
+        Write-Host "Testing upgrade: $start_ver -> $upgrade_ver"
+
+        $MinionVersion = $start_ver
+        function Get-GuestVars { "master=existing_master id=existing_minion" }
+        Write-Host "Installing salt ($MinionVersion): " -NoNewline
+        Install *> $null
+        Write-Done
+
+        $MinionVersion = $upgrade_ver
+        $Upgrade = $true
+        Write-Host "Upgrading salt ($MinionVersion): " -NoNewline
+        function Get-GuestVars { "master=gv_master id=gv_minion" }
+        Install *> $null
+        Write-Done
+        $Upgrade = $false
+
+        try {
+            $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
+        } catch {
+            $current_status = $STATUS_CODES["notInstalled"]
+        }
+        if ($current_status -ne $STATUS_CODES["installed"]) {
+            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): status not installed"
+        }
+
+        if (!(Test-Path $ssm_bin)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): ssm binary missing" }
+        if (!(Test-Path "$salt_dir\salt-call.exe")) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-call.exe missing" }
+        if (!(Test-Path "$salt_dir\salt-minion.exe")) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-minion.exe missing" }
+
+        $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
+        if (!($service)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): service not registered" }
+        elseif ($service.Status -ne "Running") { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): service not running" }
+
+        if (!(Test-Path $salt_config_file)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): config missing" }
+
+        # An upgrade preserves the existing config - the guest vars passed to
+        # the upgrade call above are expected to be ignored.
+        $minion_not_found = 1
+        $master_not_found = 1
+        foreach ($line in Get-Content $salt_config_file) {
+            if ($line -match "^id: existing_minion$") { $minion_not_found = 0 }
+            if ($line -match "^master: existing_master$") { $master_not_found = 0 }
+        }
+        if ($minion_not_found -or $master_not_found) {
+            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): config not preserved across upgrade"
+        }
+
+        $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
+        $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
+        if (!($current_path -like "*$salt_dir*")) {
+            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt not added to path"
+        }
+
+        $result = & "$salt_dir\salt-call" --local test.ping
+        if (!($result -like "local:*") -or !($result -like "*True")) {
+            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-call test.ping failed"
+        }
+
+        $result = & "$salt_dir\salt-call" --version
+        if (!($result -like "*$upgrade_ver*")) {
+            $failed = 1
+            Write-Host "FAILED ($start_ver -> $upgrade_ver): expected version $upgrade_ver, got: $result"
+        }
+
+        Write-Host "Resetting environment: " -NoNewline
+        Reset-Environment *> $null
+        Write-Done
     }
     return $failed
 }

--- a/tests/windows/integration/test_upgrade.ps1
+++ b/tests/windows/integration/test_upgrade.ps1
@@ -52,6 +52,9 @@ function test_upgrade_steps {
         Write-Done
         $Upgrade = $false
 
+        # Only check things that relate to the upgrade itself - binaries
+        # present, path, and ping are already covered by the fresh-install
+        # tests and don't exercise anything upgrade-specific.
         try {
             $current_status = Get-ItemPropertyValue -Path $vmtools_base_reg -Name $vmtools_salt_minion_status_name
         } catch {
@@ -61,15 +64,9 @@ function test_upgrade_steps {
             $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): status not installed"
         }
 
-        if (!(Test-Path $ssm_bin)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): ssm binary missing" }
-        if (!(Test-Path "$salt_dir\salt-call.exe")) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-call.exe missing" }
-        if (!(Test-Path "$salt_dir\salt-minion.exe")) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-minion.exe missing" }
-
         $service = Get-Service -Name salt-minion -ErrorAction SilentlyContinue
         if (!($service)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): service not registered" }
         elseif ($service.Status -ne "Running") { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): service not running" }
-
-        if (!(Test-Path $salt_config_file)) { $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): config missing" }
 
         # An upgrade preserves the existing config - the guest vars passed to
         # the upgrade call above are expected to be ignored.
@@ -81,17 +78,6 @@ function test_upgrade_steps {
         }
         if ($minion_not_found -or $master_not_found) {
             $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): config not preserved across upgrade"
-        }
-
-        $path_reg_key = "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment"
-        $current_path = (Get-ItemProperty -Path $path_reg_key -Name Path).Path
-        if (!($current_path -like "*$salt_dir*")) {
-            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt not added to path"
-        }
-
-        $result = & "$salt_dir\salt-call" --local test.ping
-        if (!($result -like "local:*") -or !($result -like "*True")) {
-            $failed = 1; Write-Host "FAILED ($start_ver -> $upgrade_ver): salt-call test.ping failed"
         }
 
         $result = & "$salt_dir\salt-call" --version


### PR DESCRIPTION
### What does this PR do?
Add 3008/3008.1 to generate.py's SALT_VERSIONS/VERSION_DISPLAY_NAMES and make it the single source of truth the test suites query (via new --print-versions/--print-upgrade-steps CLI modes), instead of hand-writing a new file or block per Salt major. The CI matrix now also derives one upgrade-<major> job per adjacent major pair, so future majors (3009, ...) only require a one-line edit to SALT_VERSIONS.

- Windows: test_install_major.ps1, test_install_exact_ver.ps1, and test_upgrade.ps1 read $SALT_TEST_VERSION (set from matrix.instance) to test only their assigned version/step, or loop over everything when run locally without it.
- Linux: test-linux.sh gains the same data-driven major/exact/upgrade checks, sourced from the real network (no new testarea binaries), and drops the stale "no 3008 GA yet" stub.