### PR TITLE
Replace Get-WmiObject with Get-CimInstance to fix removal under PowerShell 7

### DIFF
--- a/windows/svtminion.ps1
+++ b/windows/svtminion.ps1
@@ -553,7 +553,7 @@ function Get-ScriptRunningStatus {
 
     #Get all running powershell processes
     $filter = "Name='powershell.exe' AND CommandLine LIKE '%$script_name%'"
-    $processes = Get-WmiObject Win32_Process -Filter $filter | `
+    $processes = Get-CimInstance Win32_Process -Filter $filter | `
                  Select-Object CommandLine,ProcessId
 
     $process_found = $false
@@ -2324,9 +2324,8 @@ function Remove-SaltMinion {
 
         # Delete the service
         Write-Log "Uninstalling salt-minion service" -Level info
-        $service = Get-WmiObject -Class Win32_Service `
-                                 -Filter "Name='salt-minion'"
-        $service.delete() *> $null
+        Get-CimInstance -ClassName Win32_Service -Filter "Name='salt-minion'" |
+            Invoke-CimMethod -MethodName Delete | Out-Null
 
         try {
             # This command will throw an exception if the service is missing


### PR DESCRIPTION
### What does this PR do?
Get-WmiObject is unavailable natively in PowerShell 7 and gets proxied through the Windows PowerShell Compatibility layer, which returns a deserialized object. Calling .delete() on that proxy fails with "MethodNotFound" even though Win32_Service has a Delete method. The CIM cmdlets work natively in both Windows PowerShell 5.1 and PowerShell 7.